### PR TITLE
Allow functions in `rename` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ require('metalsmith')(__dirname)
   .use(renamer({
     filesToRename: {
       pattern: 'folder/**/*.md',
-      rename: 'newName.md'
+      rename: function(name) {
+        return 'renamed' + name;
+      }
     },
     moreFiles: {
       pattern: 'folder/about.html',
@@ -30,7 +32,7 @@ require('metalsmith')(__dirname)
 
 metalsmith-renamer has two options, both of which must be defined:
 - `pattern` option which uses [minimatch](https://github.com/isaacs/minimatch) to filter files.
-- `rename` which takes a string argument for what you'd like the files to be named.
+- `rename` which takes a string argument for what you'd like the files to be named, or a function that takes a matched file name and returns the new one to be used.
 
 ## Use cases
 - I use it to simulate [metalsmith-permalinks](https://github.com/segmentio/metalsmith-permalinks) partially by renaming certain files `index.html`, allowing me to link straight to directories and not have to use the filename. metalsmith-permalink insists on enclosing files within a structured folder system, whereas I have folder already organized manually.

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,15 @@ function plugin(options) {
           return;
         }
 
-        var renamedEntry = path.dirname(file) + "/" + options[opt].rename;
+        var rename = options[opt].rename;
+        var renamedEntry = path.dirname(file) + '/';
+
+        if (typeof rename === 'function') {
+          renamedEntry += rename(path.basename(file));
+        } else {
+          renamedEntry += rename;
+        }
+
         files[renamedEntry] = files[file];
         delete files[file];
       });


### PR DESCRIPTION
Allow both strings and functions to be passed to `rename` option, making it possible to rename files based on their names.

**Use case:** I'm using [metalsmith-permalinks](https://github.com/segmentio/metalsmith-permalinks) to rename `posts/2016-05-03-hello-world.md` to `posts/2016-05-03-hello-world/index.html`, but I also want to rename my posts prior to that so I can strip the date from each filename and end up with `posts/hello-world/index.html` as the URL. This could be done in combination with metalsmith-renamer as follows:

```js
var renamer = require('metalsmith-renamer')
var permalinks = require('metalsmith-permalinks')

metalsmith
  .use(renamer({
    posts: {
      pattern: 'posts/*.md',
      rename: (name) => name.substr(11) // remove `YYYY-MM-DD-` prefix
    }
  }))
  .use(permalinks())
```