### PR TITLE
Avoid `./` prefix when renaming a root file

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,9 @@ function plugin(options) {
         var rename = options[opt].rename;
         var renamedEntry = path.dirname(file) + '/';
 
+        if (renamedEntry === './') {
+          renamedEntry = '';
+        }
         if (typeof rename === 'function') {
           renamedEntry += rename(path.basename(file));
         } else {


### PR DESCRIPTION
The title says it all. Basically, when renaming a file that is directly under the source directory, the new file path is prefixed with `./`.