### PR TITLE
Only Rename if Name Changed

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26,8 +26,10 @@ function plugin(options) {
           renamedEntry += rename;
         }
 
-        files[renamedEntry] = files[file];
-        delete files[file];
+        if (renamedEntry !== file) {
+          files[renamedEntry] = files[file];
+          delete files[file];
+        }
       });
     });
     done();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsmith-renamer",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Plugin to take a pattern and rename each matched file",
   "main": "lib/index.js",
   "repository": {


### PR DESCRIPTION
Solves https://github.com/alex-ketch/metalsmith-renamer/issues/4.

Right now if the renamed filename is the same as the original filename the file gets removed entirely.

This change leaves the original file alone if the name did not change.